### PR TITLE
feat(emails): Add email interaction status tracking to EmailLogList

### DIFF
--- a/src/components/emails/EmailLogList.tsx
+++ b/src/components/emails/EmailLogList.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Mail, User, Calendar, History } from 'lucide-react';
+import { Mail, User, Calendar, History, Eye, MessageSquare } from 'lucide-react';
 import { EmailLog } from '../../services/emails';
 import { formatDateTime } from '../../utils/formatters';
 import { EmailHistoryDialog } from './EmailHistoryDialog';
@@ -35,6 +35,7 @@ export function EmailLogList({ emailLogs, isLoading }: EmailLogListProps) {
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Lead</th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Campaign</th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Sent at</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
                 </tr>
               </thead>
@@ -57,6 +58,18 @@ export function EmailLogList({ emailLogs, isLoading }: EmailLogListProps) {
                       <div className="flex items-center text-sm text-gray-900">
                         <Calendar className="h-4 w-4 mr-1 text-gray-400" />
                         {formatDateTime(log.sent_at)}
+                      </div>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <div className="flex items-center space-x-2">
+                        <div className={`flex items-center ${log.has_opened ? 'text-green-600' : 'text-gray-400'}`}>
+                          <Eye className="h-4 w-4 mr-1" />
+                          <span className="text-sm">{log.has_opened ? 'Opened' : 'Not opened'}</span>
+                        </div>
+                        <div className={`flex items-center ${log.has_replied ? 'text-blue-600' : 'text-gray-400'}`}>
+                          <MessageSquare className="h-4 w-4 mr-1" />
+                          <span className="text-sm">{log.has_replied ? 'Replied' : 'No reply'}</span>
+                        </div>
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">

--- a/src/services/emails.ts
+++ b/src/services/emails.ts
@@ -8,6 +8,8 @@ export interface EmailLog {
   campaign_name: string | null;
   lead_name: string | null;
   lead_email: string | null;
+  has_opened: boolean;
+  has_replied: boolean;
 }
 
 export interface EmailHistory {


### PR DESCRIPTION
- Introduce has_opened and has_replied fields to EmailLog interface
- Add status column in EmailLogList with visual indicators for email interactions
- Display email open and reply status using Eye and MessageSquare icons
- Color-code status indicators based on interaction state