### PR TITLE
Add retry functionality for call queue items in CallQueues component

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -67,6 +67,7 @@ export const apiEndpoints = {
   calls: {
     details: (callId: string) => `${config.apiUrl}/api/calls/${callId}`,
     webhook: `${config.apiUrl}/api/calls/webhook`,
+    retry: (queueId: string) => `${config.apiUrl}/api/call-queues/${queueId}/retry`,
   },
   campaigns: {
     run: (campaignId: string) => `${config.apiUrl}/api/campaigns/${campaignId}/run`,

--- a/src/services/calls.ts
+++ b/src/services/calls.ts
@@ -42,6 +42,12 @@ export interface PaginatedCallResponse {
   total_pages: number;
 }
 
+export interface CallQueueRetryResponse {
+  message: string;
+  queue_id: string;
+  status: string;
+}
+
 export async function getCompanyCalls(
   token: string, 
   companyId: string, 
@@ -156,6 +162,32 @@ export async function retryFailedCampaignCalls(
   
   if (!response.ok) {
     const error = new Error('Failed to retry campaign calls') as any;
+    error.response = {
+      status: response.status,
+      data: data
+    };
+    throw error;
+  }
+
+  return data;
+}
+
+export async function retryCallQueueItem(
+  token: string,
+  queueId: string
+): Promise<CallQueueRetryResponse> {
+  const response = await fetch(apiEndpoints.calls.retry(queueId), {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  const data = await response.json();
+  
+  if (!response.ok) {
+    const error = new Error('Failed to retry call queue item') as any;
     error.response = {
       status: response.status,
       data: data


### PR DESCRIPTION
- Implemented a new handleRetryQueueItem function to allow users to retry failed call queue items.
- Updated the CallQueues component to include a retry button for failed items, enhancing user interaction.
- Added a new API endpoint for retrying call queue items in the service layer.
- Improved error handling and user feedback during the retry process.