### PR TITLE
Add status filter to EmailLogFilters component

### DIFF
--- a/src/components/emails/EmailLogFilters.tsx
+++ b/src/components/emails/EmailLogFilters.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Filter, Search } from 'lucide-react';
+import { Filter, Search, MessageSquare } from 'lucide-react';
 import { getCompanyCampaigns, Campaign } from '../../services/emailCampaigns';
 import { getToken } from '../../utils/auth';
 import type { EmailLogFilters } from '../../hooks/useEmailLogs';
@@ -110,6 +110,20 @@ export function EmailLogFilters({ filters, onFilterChange, companyId }: EmailLog
               {campaign.name}
             </option>
           ))}
+        </select>
+      </div>
+
+      <div className="flex items-center space-x-2">
+        <MessageSquare className="h-5 w-5 text-gray-400" />
+        <select
+          value={filters.status || ''}
+          onChange={(e) => onFilterChange({ ...filters, status: (e.target.value || undefined) as any })}
+          className="block min-w-[150px] pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md"
+        >
+          <option value="">All</option>
+          <option value="opened">Opened</option>
+          <option value="replied">Replied</option>
+          <option value="meeting_booked">Meeting Booked</option>
         </select>
       </div>
 

--- a/src/hooks/useEmailLogs.ts
+++ b/src/hooks/useEmailLogs.ts
@@ -6,6 +6,7 @@ import { useToast } from '../context/ToastContext';
 export interface EmailLogFilters {
   campaign_id?: string;
   lead_id?: string;
+  status?: 'opened' | 'replied' | 'meeting_booked';
 }
 
 interface UseEmailLogsProps {
@@ -70,7 +71,8 @@ export function useEmailLogs({ companyId, campaignRunId }: UseEmailLogsProps): U
         filters.lead_id,
         campaignRunId,
         page,
-        pageSize
+        pageSize,
+        filters.status
       );
 
       setEmailLogs(response.items);
@@ -126,4 +128,4 @@ export function useEmailLogs({ companyId, campaignRunId }: UseEmailLogsProps): U
     setFilters,
     refetch: fetchEmailLogs,
   };
-} 
+}

--- a/src/services/emails.ts
+++ b/src/services/emails.ts
@@ -40,7 +40,8 @@ export async function getCompanyEmails(
   leadId?: string,
   campaignRunId?: string,
   page: number = 1,
-  pageSize: number = 10
+  pageSize: number = 10,
+  status?: 'opened' | 'replied' | 'meeting_booked'
 ): Promise<PaginatedEmailLogResponse> {
   const url = new URL(`${apiEndpoints.companies.emails.list(companyId)}`);
   
@@ -54,6 +55,10 @@ export async function getCompanyEmails(
   
   if (campaignRunId) {
     url.searchParams.append('campaign_run_id', campaignRunId);
+  }
+
+  if (status) {
+    url.searchParams.append('status', status);
   }
   
   url.searchParams.append('page_number', page.toString());


### PR DESCRIPTION
- Introduced a new status filter in the EmailLogFilters component, allowing users to filter email logs by status (opened, replied, meeting booked).
- Updated the EmailLogFilters interface to include the new status property.
- Modified the getCompanyEmails function to accept and handle the status parameter for filtering email logs.