### PR TITLE
Implement duplicate account check in CompanySettings

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -56,6 +56,7 @@ export const apiEndpoints = {
       list: (companyId: string) => `${config.apiUrl}/api/companies/${companyId}/campaign-runs`,
     },
     accountCredentials: (companyId: string) => `${config.apiUrl}/api/companies/${companyId}/account-credentials`,
+    checkDuplicateAccount: (companyId: string, accountEmail: string) => `${config.apiUrl}/api/companies/${companyId}/accounts/${accountEmail}/check-duplicate`,
     voiceAgentSettings: (companyId: string) => `${config.apiUrl}/api/companies/${companyId}/voice_agent_settings`,
     invite: (companyId: string) => `${config.apiUrl}/api/companies/${companyId}/invite`,
     users: (companyId: string) => `${config.apiUrl}/api/companies/${companyId}/users`,

--- a/src/services/companies.ts
+++ b/src/services/companies.ts
@@ -20,6 +20,7 @@ export interface Company {
   total_leads: number;
   products: Product[];
   voice_agent_settings?: VoiceAgentSettings;
+  custom_calendar_link?: string;
 }
 
 export interface CompanyCreate {


### PR DESCRIPTION
- Added functionality to check for duplicate email accounts when updating account credentials in the CompanySettings component.
- Introduced a warning dialog to inform users if the email is already associated with another company, preventing potential issues with account limits.
- Updated API endpoints to support duplicate account verification.
- Enhanced the Company interface to include custom_calendar_link property for better data management.